### PR TITLE
openBDでサーバーエラーが起こった際のエラー処理修正

### DIFF
--- a/lib/open_bd/api.rb
+++ b/lib/open_bd/api.rb
@@ -13,7 +13,12 @@ module OpenBd
     def get_json
       uri = URI.parse(@base_uri)
       json = Net::HTTP.get(uri)
-      result = JSON.parse(json, {:symbolize_names => true})
+      begin
+        result = JSON.parse(json, {:symbolize_names => true})
+      rescue
+        sleep(3)
+        retry
+      end
     end
 
     def get_description


### PR DESCRIPTION
* 下記のエラーを修正
```
JSON::ParserError: 751: unexpected token at '<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 502 (Server Error)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>502.</b> <ins>That’s an error.</ins>
  <p>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.  <ins>That’s all we know.</ins>
'
/var/www/labooks/lib/open_bd/api.rb:16:in `get_json'
/var/www/labooks/lib/open_bd/api.rb:20:in `get_description'
/var/www/labooks/lib/tasks/books.rake:20:in `block (3 levels) in <top (required)>'
/var/www/labooks/vendor/bundle/ruby/2.4.0/gems/activerecord-5.1.1/lib/active_record/relation/delegation.rb:41:in `each'
/var/www/labooks/vendor/bundle/ruby/2.4.0/gems/activerecord-5.1.1/lib/active_record/relation/delegation.rb:41:in `each'
/var/www/labooks/lib/tasks/books.rake:18:in `block (2 levels) in <top (required)>'
/usr/local/rbenv/versions/2.4.2/bin/bundle:23:in `load'
/usr/local/rbenv/versions/2.4.2/bin/bundle:23:in `<main>'
Tasks: TOP => books:get_description
(See full trace by running task with --trace)
[ryuki@150-95-157-57 labooks]$ RAILS_ENV=production bundle exec rake books:get_description
```