### PR TITLE
hostnameをセットし、actionmailerのエラーを修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,7 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "labooks_#{Rails.env}"
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: ENV['DEFAULT_URL'] }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
* hostnameを設定し、下記のエラーを修正
```
F, [2018-01-21T15:28:02.647047 #15931] FATAL -- : [3580fb27-630a-4924-b117-bfd31054d5cb] ActionView::Template::Error (Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true):
```